### PR TITLE
Use message property of vaadin-confirm-dialog

### DIFF
--- a/src/vaadin-crud.html
+++ b/src/vaadin-crud.html
@@ -66,14 +66,14 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
     <vaadin-confirm-dialog theme$="[[theme]]" id="confirmCancel" on-confirm="__confirmCancel"
       cancel confirm-text="[[i18n.confirm.cancel.button.confirm]]"
       cancel-text="[[i18n.confirm.cancel.button.dismiss]]"
-      header="[[i18n.confirm.cancel.title]]" confirm-theme="primary">
-      [[i18n.confirm.cancel.content]]
+      header="[[i18n.confirm.cancel.title]]" 
+      message="[[i18n.confirm.cancel.content]]" confirm-theme="primary">
     </vaadin-confirm-dialog>
     <vaadin-confirm-dialog theme$="[[theme]]" id="confirmDelete" on-confirm="__confirmDelete"
       cancel confirm-text="[[i18n.confirm.delete.button.confirm]]"
       cancel-text="[[i18n.confirm.delete.button.dismiss]]"
-      header="[[i18n.confirm.delete.title]]" confirm-theme="primary error">
-      [[i18n.confirm.delete.content]]
+      header="[[i18n.confirm.delete.title]]" 
+      message="[[i18n.confirm.delete.content]]" confirm-theme="primary error">
     </vaadin-confirm-dialog>
   </template>
 


### PR DESCRIPTION
There seems to be no benefit on using the default slot of the confirm dialog.
And using the property makes it more uniform and provides a better experience
when inspecting DOM and when using TB Element API of confirm dialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-crud/151)
<!-- Reviewable:end -->
