### PR TITLE
use theme property defined in theme-property-mixin

### DIFF
--- a/src/vaadin-crud.html
+++ b/src/vaadin-crud.html
@@ -193,11 +193,6 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
               type: HTMLElement,
               observer: '__onFormChange'
             },
-            /** The theme to use and to apply to the generated elements */
-            theme: {
-              type: String,
-              reflectToAttribute: true
-            },
             /**
              * An array containing the items which will be stamped to the column template instances.
              */


### PR DESCRIPTION
vaadin-theme-property-mixin defines theme read-only theme property that is updated from the theme attribute https://github.com/vaadin/vaadin-themable-mixin/blob/master/vaadin-theme-property-mixin.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-crud/153)
<!-- Reviewable:end -->
