### PR TITLE
Downgrade vaadin button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "vaadin-grid": "^5.4.5",
     "vaadin-form-layout": "^2.1.4",
     "vaadin-text-field": "^2.4.5",
-    "vaadin-button": "^2.2.0",
+    "vaadin-button": "^2.1.0",
     "vaadin-confirm-dialog": "^1.1.1",
     "vaadin-license-checker": "vaadin/license-checker#^2.1.0"
   },


### PR DESCRIPTION
Version of vaadin-button in platform is 2.1.0 for v13. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-crud/164)
<!-- Reviewable:end -->
