### PR TITLE
Prevent trigger "cancel" event twice

### DIFF
--- a/src/vaadin-crud.html
+++ b/src/vaadin-crud.html
@@ -570,7 +570,7 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           if (item) {
             this.__edit(item);
           } else {
-            this.__cancel();
+            this.__closeEditor();
           }
         }
 
@@ -581,10 +581,13 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
             this.editedItem !== item // Item is different
           ) {
             this.$.confirmCancel.opened = true;
-
             const listenOnce = (event) => {
               event.preventDefault(); // prevent editor to get closed
-              this.__edit(item);
+              if (item) {
+                this.__edit(item);
+              } else {
+                this.__closeEditor();
+              }
               this.removeEventListener('cancel', listenOnce);
             };
             this.addEventListener('cancel', listenOnce);

--- a/test/crud-test.html
+++ b/test/crud-test.html
@@ -257,6 +257,36 @@
               expect(crud.$.confirmCancel.opened).not.to.be.ok;
               expect(crud.$.dialog.opened).not.to.be.ok;
             });
+
+            it('should trigger "cancel" only once after user hits "Cancel"', (done) => {
+              crud.clickRowToEdit = true;
+
+              const cancelSpyListener = sinon.spy();
+              crud.addEventListener('cancel', cancelSpyListener);
+
+              crud._grid.activeItem = crud.items[0];
+              btnCancel().click();
+              setTimeout(() => {
+                expect(cancelSpyListener.calledOnce).to.be.ok;
+                done();
+              });
+            });
+
+            it('should not trigger "cancel" after user hits "Save"', (done) => {
+              crud.clickRowToEdit = true;
+
+              const cancelSpyListener = sinon.spy();
+              crud.addEventListener('cancel', cancelSpyListener);
+
+              crud._grid.activeItem = crud.items[0];
+              edit(crud.items[0]);
+              change();
+              btnSave().click();
+              setTimeout(() => {
+                expect(cancelSpyListener.notCalled).to.be.ok;
+                done();
+              });
+            });
           });
 
           describe('delete', () => {

--- a/test/crud-test.html
+++ b/test/crud-test.html
@@ -783,6 +783,15 @@
           crud._grid.activeItem = null; // A second click will set grid active item to null
           expect(crud.editorOpened).to.be.false;
         });
+
+        it('should close editor after a second click on the same row after dirty editor is discarded', () => {
+          fakeClickOnRow(0);
+          expect(crud.editorOpened).to.be.true;
+          crud.__isDirty = true;
+          crud._grid.activeItem = null; // A second click will set grid active item to null
+          btnConfDialog(crud.$.confirmCancel, 'confirm').click();
+          expect(crud.editorOpened).to.be.false;
+        });
       });
     });
   </script>


### PR DESCRIPTION
Because of changes on #173, to Crud#__cancel() method was being used in order to close the editor which would provide some weird cases where a cancel event being sent after save and cancel being triggered twice in a row.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-crud/175)
<!-- Reviewable:end -->
