### PR TITLE
Prompt discard confirmation on New click and dirty

### DIFF
--- a/src/vaadin-crud.html
+++ b/src/vaadin-crud.html
@@ -571,10 +571,6 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           } else if (!this.__keepOpened) {
             this.__closeEditor();
           }
-
-          if (this.__keepOpened) {
-            delete this.__keepOpened;
-          }
         }
 
         __confirmBeforeChangingEditedItem(item, keepOpened) {

--- a/src/vaadin-crud.html
+++ b/src/vaadin-crud.html
@@ -566,15 +566,18 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
             this.__confirmBeforeChangingEditedItem(item);
             return;
           }
-
           if (item) {
             this.__edit(item);
-          } else {
+          } else if (!this.__keepOpened) {
             this.__closeEditor();
+          }
+
+          if (this.__keepOpened) {
+            delete this.__keepOpened;
           }
         }
 
-        __confirmBeforeChangingEditedItem(item) {
+        __confirmBeforeChangingEditedItem(item, keepOpened) {
           if (
             this.editorOpened && // Editor opened
             this.__isDirty && // Form change has been made
@@ -583,8 +586,9 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
             this.$.confirmCancel.opened = true;
             const listenOnce = (event) => {
               event.preventDefault(); // prevent editor to get closed
-              if (item) {
+              if (item || keepOpened) {
                 this.__edit(item);
+                this.__clearItemAndKeepEditorOpened(item, keepOpened);
               } else {
                 this.__closeEditor();
               }
@@ -593,6 +597,16 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
             this.addEventListener('cancel', listenOnce);
           } else {
             this.__edit(item);
+            this.__clearItemAndKeepEditorOpened(item, keepOpened);
+          }
+        }
+
+        __clearItemAndKeepEditorOpened(item, keepOpened) {
+          if (!item) {
+            setTimeout(() => {
+              this.__keepOpened = keepOpened;
+              this.editedItem = this._grid.activeItem = undefined;
+            });
           }
         }
 
@@ -641,7 +655,9 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           }
 
           this.__isNew = this.__isNew || this.items && this.items.indexOf(item) < 0;
-          this.editorOpened = !!item;
+          if (item) {
+            this.editorOpened = true;
+          }
         }
 
         /** A reference to all fields inside the [`_form`](#/elements/vaadin-crud#property-_form) element */
@@ -668,13 +684,13 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           this.__setHighlightedItem(null);
 
           // Delay changing the item in order not to modify editor while closing
-          setTimeout(() => this.editedItem = this._grid.activeItem = undefined);
+          setTimeout(() => this.__clearItemAndKeepEditorOpened(null, false));
         }
 
         __new(event) {
           // This allows listening to parent element and fire only when clicking on default or custom new-button.
           if (event.composedPath().filter(e => e.nodeType == 1 && e.hasAttribute('new-button'))[0]) {
-            this.__openEditor('new');
+            this.__confirmBeforeChangingEditedItem(null, true);
           }
         }
 

--- a/test/crud-test.html
+++ b/test/crud-test.html
@@ -883,6 +883,45 @@
           btnConfDialog(crud.$.confirmCancel, 'confirm').click();
           expect(crud.editorOpened).to.be.false;
         });
+
+        it('should open same row again after item closed after click on "New"', (done) => {
+          crud.__mobile = false;
+
+          fakeClickOnRow(0);
+          expect(crud.editorOpened).to.be.true;
+          crud.$.new.click();
+          setTimeout(() => {
+            expect(crud.editorOpened).to.be.true;
+            setTimeout(() => {
+              expect(crud._grid.activeItem).to.be.undefined;
+              fakeClickOnRow(0);
+              expect(crud.editorOpened).to.be.true;
+              expect(crud.editedItem).to.be.equal(crud.items[0]);
+              done();
+            });
+          });
+        });
+
+        it('should open same row again after item was discarded after click on "New"', (done) => {
+          crud.__mobile = false;
+
+          fakeClickOnRow(0);
+          expect(crud.editorOpened).to.be.true;
+          crud.__isDirty = true;
+          crud.$.new.click();
+          setTimeout(() => {
+            expect(crud.$.confirmCancel.opened).to.be.true;
+            btnConfDialog(crud.$.confirmCancel, 'confirm').click();
+            expect(crud.editorOpened).to.be.true;
+            setTimeout(() => {
+              expect(crud._grid.activeItem).to.be.undefined;
+              fakeClickOnRow(0);
+              expect(crud.editorOpened).to.be.true;
+              expect(crud.editedItem).to.be.equal(crud.items[0]);
+              done();
+            });
+          });
+        });
       });
     });
   </script>

--- a/test/crud-test.html
+++ b/test/crud-test.html
@@ -362,6 +362,34 @@
             expect(crud.editedItem).to.be.equal(crud.items[0]);
           });
 
+          it('should prompt confirm if dirty and new button is clicked', () => {
+            crud.editorPosition = 'bottom';
+            crud.editOnClick = true;
+            crud.items = [{foo: 'bar'}, {foo: 'baz'}];
+
+            crud._grid.activeItem = crud.items[0];
+            expect(crud.editorOpened).to.be.true;
+            change();
+
+            crud.$.new.click();
+            expect(crud.$.confirmCancel.opened).to.be.true;
+          });
+
+          it('should keep editor opened if dirty, new button is clicked and changes are discarded', () => {
+            crud.editorPosition = 'bottom';
+            crud.editOnClick = true;
+            crud.items = [{foo: 'bar'}, {foo: 'baz'}];
+
+            crud._grid.activeItem = crud.items[0];
+            expect(crud.editorOpened).to.be.true;
+            change();
+
+            crud.$.new.click();
+            expect(crud.$.confirmCancel.opened).to.be.true;
+            btnConfDialog(crud.$.confirmCancel, 'confirm').click();
+            expect(crud.editorOpened).to.be.true;
+          });
+
           it('should change edited items if dirty when user discard changes', () => {
             crud.editorPosition = 'bottom';
             crud.editOnClick = true;


### PR DESCRIPTION
Open a confirmation dialog to discard changes if user clicks on New button and editor is dirty.

Fixes #180

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-crud/181)
<!-- Reviewable:end -->
