### PR TITLE
fix(editorHeader): compute editor header from isNew and i18n

### DIFF
--- a/src/vaadin-crud.html
+++ b/src/vaadin-crud.html
@@ -73,7 +73,7 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
         </div>
       </div>
       <vaadin-dialog-layout theme$="[[theme]]" id="dialog" no-close-on-outside-click=[[__isDirty]] no-close-on-esc=[[__isDirty]] opened="{{editorOpened}}" editor-position$="{{editorPosition}}" mobile="[[__mobile]]" theme="crud">
-        <h3 slot="header">[[__editorHeader]]</h3>
+        <h3 slot="header">[[__computeEditorHeader(__isNew, i18n.newItem, i18n.editItem)]]</h3>
         <div id="editor">
           <slot name="form">
             <vaadin-crud-form theme$="[[theme]]" id="form" include="[[include]]" exclude="[[exclude]]"></vaadin-crud-form>
@@ -396,7 +396,6 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
             },
             __isDirty: Boolean,
             __isNew: Boolean,
-            __editorHeader: String,
             __mobileMediaQuery: {
               value: '(max-width: 600px), (max-height: 600px)'
             },
@@ -431,6 +430,10 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           this._form = this.$.form;
         }
 
+        __computeEditorHeader(isNew, newItem, editItem) {
+          return isNew ? newItem : editItem;
+        }
+
         __onI18Change(i18n, grid) {
           if (grid) {
             Polymer.RenderStatus.afterNextRender(grid, () => {
@@ -457,7 +460,6 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           if (!opened && old) {
             this.__closeEditor();
           } else {
-            this.__editorHeader = this.__isNew ? this.i18n.newItem : this.i18n.editItem;
             this.__onFormChange(this._form);
           }
 

--- a/test/crud-test.html
+++ b/test/crud-test.html
@@ -54,6 +54,8 @@
       const btnCancel = () => buttons()[1];
       const btnDelete = () => buttons()[2];
 
+      const editorHeader = () => crud.$.dialog.$.dialog.$.overlay.shadowRoot.querySelector('[slot=header]');
+
       const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
       // Buttons in confirm dialogs
@@ -102,7 +104,7 @@
 
         it('should open the new item editor if item is provided declarativelly', () => {
           expect(crud.editorOpened).to.be.true;
-          expect(crud.__editorHeader).to.be.equal('New item');
+          expect(crud.__isNew).to.be.true;
         });
 
         it('should be able to internationalise via `i18n` property', done => {
@@ -169,6 +171,25 @@
         beforeEach(done => {
           crud.items = [{foo: 'bar'}];
           Polymer.RenderStatus.afterNextRender(crud._grid, done);
+        });
+
+        describe('editor header', () => {
+          it('should have new item title', () => {
+            crud.$.new.click();
+            expect(editorHeader().textContent).to.be.equal('New item');
+          });
+
+          it('should have edit item title', () => {
+            crud.editedItem = crud.items[0];
+            expect(editorHeader().textContent).to.be.equal('Edit item');
+          });
+
+          it('should change to new item title', () => {
+            crud.editedItem = crud.items[0];
+            expect(editorHeader().textContent).to.be.equal('Edit item');
+            crud.$.new.click();
+            expect(editorHeader().textContent).to.be.equal('New item');
+          });
         });
 
         describe('actions', () => {


### PR DESCRIPTION
Header was only updated when opened changed and that caused
issues when edit/new mode changed without closing editor

Also changes in i18n were not updated without reopening

Fixes #183

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-crud/184)
<!-- Reviewable:end -->
