### PR TITLE
refactor: only run license checker when needed

### DIFF
--- a/src/vaadin-crud.html
+++ b/src/vaadin-crud.html
@@ -413,6 +413,19 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           ];
         }
 
+        /**
+         * @protected
+         */
+        static _finalizeClass() {
+          super._finalizeClass();
+
+          const devModeCallback = window.Vaadin.developmentModeCallback;
+          const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
+          if (typeof licenseChecker === 'function') {
+            licenseChecker(CrudElement);
+          }
+        }
+
         constructor() {
           super();
           this._observer = new Polymer.FlattenedNodesObserver(this, info => {
@@ -819,12 +832,6 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
        * @namespace Vaadin
        */
       window.Vaadin.CrudElement = CrudElement;
-
-      const licenseChecker = window.Vaadin.developmentModeCallback
-        && window.Vaadin.developmentModeCallback['vaadin-license-checker'];
-      if (typeof licenseChecker === 'function') {
-        licenseChecker(CrudElement);
-      }
     })();
   </script>
 </dom-module>


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#492

This PR makes sure the license checker is only called when the component is created.
The static `_finalizeClass` method is needed to ensure we call it [once per class](https://github.com/Polymer/polymer/blob/f6ccc9d1bdc81e934e21bf27b3dba517b5840fd4/lib/mixins/properties-mixin.js#L138-L147).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-crud/185)
<!-- Reviewable:end -->
