### PR TITLE
fix: add missing property change events [skip ci]

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,9 +1,6 @@
-import { GridFilter, GridSorter } from '@vaadin/vaadin-grid'
+import { GridFilter, GridSorter } from '@vaadin/vaadin-grid';
 
-export type CrudDataProviderCallback<T> = (
-  items: Array<T>,
-  size?: number
-) => void;
+export type CrudDataProviderCallback<T> = (items: Array<T>, size?: number) => void;
 
 export type CrudDataProviderParams = {
   page: number;
@@ -12,12 +9,9 @@ export type CrudDataProviderParams = {
   sortOrders: Array<GridSorter>;
 };
 
-export type CrudDataProvider<T> = (
-  params: CrudDataProviderParams,
-  callback: CrudDataProviderCallback<T>
-) => void;
+export type CrudDataProvider<T> = (params: CrudDataProviderParams, callback: CrudDataProviderCallback<T>) => void;
 
-export type CrudEditorPosition = '' | 'bottom' | 'aside';
+export type CrudEditorPosition = '' | 'bottom' | 'aside';
 
 export interface CrudI18n {
   newItem: string;
@@ -33,17 +27,17 @@ export interface CrudI18n {
       button: {
         confirm: string;
         dismiss: string;
-      }
-    },
+      };
+    };
     cancel: {
       title: string;
       content: string;
       button: {
         confirm: string;
         dismiss: string;
-      }
-    }
-  }
+      };
+    };
+  };
 }
 
 /**

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -47,6 +47,21 @@ export interface CrudI18n {
 }
 
 /**
+ * Fired when the `editorOpened` property changes.
+ */
+export type CrudEditorOpenedChanged = CustomEvent<{ value: boolean }>;
+
+/**
+ * Fired when the `items` property changes.
+ */
+export type CrudItemsChanged<T> = CustomEvent<{ value: Array<T> }>;
+
+/**
+ * Fired when the `size` property changes.
+ */
+export type CrudSizeChanged = CustomEvent<{ value: number }>;
+
+/**
  * Fired when user wants to create a new item.
  */
 export type CrudNew = CustomEvent<{ item: null }>;
@@ -72,6 +87,12 @@ export type CrudCancel<T> = CustomEvent<{ item: T }>;
 export type CrudSave<T> = CustomEvent<{ item: T; new: boolean }>;
 
 export type CrudElementEventMap<T> = {
+  'editor-opened-changed': CrudEditorOpenedChanged;
+
+  'items-changed': CrudItemsChanged<T>;
+
+  'size-changed': CrudSizeChanged;
+
   'new': CrudNew;
 
   'cancel': CrudCancel<T>;

--- a/src/vaadin-crud.d.ts
+++ b/src/vaadin-crud.d.ts
@@ -98,6 +98,9 @@ import { CrudDataProvider, CrudEditorPosition, CrudEventMap, CrudI18n } from './
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} new - Fired when user wants to create a new item.
  * @fires {CustomEvent} edit - Fired when user wants to edit an existing item.
  * @fires {CustomEvent} delete - Fired when user wants to delete item.

--- a/src/vaadin-crud.js
+++ b/src/vaadin-crud.js
@@ -111,6 +111,9 @@ import './vaadin-crud-form.js';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} new - Fired when user wants to create a new item.
  * @fires {CustomEvent} edit - Fired when user wants to edit an existing item.
  * @fires {CustomEvent} delete - Fired when user wants to delete item.

--- a/test/typings/crud.types.ts
+++ b/test/typings/crud.types.ts
@@ -12,6 +12,18 @@ type User = {
 
 const crud: CrudElement<User> = document.createElement('vaadin-crud');
 
+crud.addEventListener('editor-opened-changed', (event) => {
+  assert<boolean>(event.detail.value);
+});
+
+crud.addEventListener('items-changed', (event) => {
+  assert<User[]>(event.detail.value);
+});
+
+crud.addEventListener('size-changed', (event) => {
+  assert<number>(event.detail.value);
+});
+
 crud.addEventListener('new', (event) => {
   assert<null>(event.detail.item);
 });


### PR DESCRIPTION
This PR aligns the events type definitions with the list in the [API docs](https://cdn.vaadin.com/vaadin-crud/2.0.0-alpha2/#/elements/vaadin-crud#events).