### PR TITLE
fix: notify editedItem

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -46,6 +46,12 @@ export interface CrudI18n {
 export type CrudEditorOpenedChanged = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `editedItem` property changes.
+ */
+export type CrudEditedItemChanged<T> = CustomEvent<{ value: T }>;
+
+
+/**
  * Fired when the `items` property changes.
  */
 export type CrudItemsChanged<T> = CustomEvent<{ value: Array<T> }>;
@@ -82,6 +88,8 @@ export type CrudSave<T> = CustomEvent<{ item: T; new: boolean }>;
 
 export type CrudElementEventMap<T> = {
   'editor-opened-changed': CrudEditorOpenedChanged;
+
+  'edited-item-changed': CrudEditedItemChanged<T>;
 
   'items-changed': CrudItemsChanged<T>;
 

--- a/src/vaadin-crud.d.ts
+++ b/src/vaadin-crud.d.ts
@@ -99,6 +99,7 @@ import { CrudDataProvider, CrudEditorPosition, CrudEventMap, CrudI18n } from './
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
  * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
+ * @fires {CustomEvent} edited-item-changed - Fired when `editedItem` property changes.
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} new - Fired when user wants to create a new item.

--- a/src/vaadin-crud.js
+++ b/src/vaadin-crud.js
@@ -112,6 +112,7 @@ import './vaadin-crud-form.js';
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
  * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
+ * @fires {CustomEvent} edited-item-changed - Fired when `editedItem` property changes.
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} new - Fired when user wants to create a new item.
@@ -294,7 +295,8 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
        */
       editedItem: {
         type: Object,
-        observer: '__onItemChange'
+        observer: '__onItemChange',
+        notify: true
       },
 
       /**

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -191,6 +191,14 @@ describe('crud', () => {
         crud.items = [{ foo: 'bar' }, { foo: 'baz' }];
       });
 
+      it('should notify editedItem changes', (done) => {
+        listenOnce(crud, 'edited-item-changed', () => {
+          expect(crud.editedItem).to.deep.equal({ foo: 'bar' });
+          done();
+        });
+        edit(crud.items[0]);
+      });
+
       it('should save a new pre-filled item', () => {
         crud.editedItem = { foo: 'baz' };
         crud._form._fields[0].value = 'baz';

--- a/test/typings/crud.types.ts
+++ b/test/typings/crud.types.ts
@@ -16,6 +16,10 @@ crud.addEventListener('editor-opened-changed', (event) => {
   assert<boolean>(event.detail.value);
 });
 
+crud.addEventListener('edited-item-changed', (event) => {
+  assert<User>(event.detail.value);
+});
+
 crud.addEventListener('items-changed', (event) => {
   assert<User[]>(event.detail.value);
 });


### PR DESCRIPTION
Fixes #241 

Makes sure `editedItem` is notifying its changes.